### PR TITLE
Bump log4j-api from 2.13.2 to 2.13.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.13.2</version>
+      <version>2.13.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Bumps log4j-api from 2.13.2 to 2.13.3.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>