### PR TITLE
Bump log4j-core from 2.13.2 to 2.13.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.13.2</version>
+      <version>2.13.3</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Bumps log4j-core from 2.13.2 to 2.13.3.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>